### PR TITLE
Add customheader yaml to root of project

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,13 @@
+# Custom headers when serving docs through Amplify Hosting
+#
+# See: https://docs.aws.amazon.com/amplify/latest/userguide/custom-headers.html#setting-custom-headers
+
+customHeaders:
+  - pattern: "**/*.raw.html"
+    headers:
+      - key: Access-Control-Allow-Origin
+        value: "*"
+  - pattern: "**/*"
+    headers:
+      - key: Cache-Control
+        value: s-maxage=600


### PR DESCRIPTION
Adding this file to the `root` of the project will overwrite the settings within **Amplify**. 
This way we can control it from outside **Amplify** (so dev's can do it themselves) and we don't have to set it for every deploy.