### PR TITLE
Serve the docs preview under a /docs base

### DIFF
--- a/dev/preview.sh
+++ b/dev/preview.sh
@@ -5,5 +5,10 @@ SCRIPT_PATH=$(readlink -f "${0}")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 
 cd ..
-npm run docs:build
-npm run docs:preview -- --host --port 24173
+
+# The dev stack serves these docs behind the GRIP gateway at /docs; production
+# serves them at the domain root via Amplify. Build and preview under that base
+# so asset and link URLs resolve through the gateway.
+BASE="${DOCS_BASE:-/docs/}"
+npm run docs:build -- --base "${BASE}"
+npm run docs:preview -- --host --port 24173 --base "${BASE}"


### PR DESCRIPTION
Make base flexible to facilitate local dev setups.

---
<details>
<summary>LLM-generated technical summary</summary>

The dev preview now builds and serves under a configurable base via `DOCS_BASE` (default `/docs/`), so the local docs resolve through the GRIP gateway's `/docs` route. Pairs with the gateway StripPrefix removal in GRIP #626: with the prefix kept, the built `/docs/...` URLs escaped to the frontend catch-all and the docs rendered unstyled. `config.mts` sets no base, so the Amplify production build stays at root.
</details>
